### PR TITLE
feat: Add persistent Slack OAuth integration

### DIFF
--- a/client/src/components/SlackConnectCard.tsx
+++ b/client/src/components/SlackConnectCard.tsx
@@ -1,0 +1,195 @@
+import React, { useState } from 'react';
+import { useSlackAuth } from '../hooks/useSlackAuth';
+import { apiClient } from '../lib/api';
+import { useTenant } from '../context/TenantContext';
+
+const SlackConnectCard: React.FC = () => {
+  const { tenantId } = useTenant();
+  const { authStatus, loading, polling, error, checkAuth, refreshToken, startPolling, stopPolling } = useSlackAuth({ tenantId });
+  const [connecting, setConnecting] = useState(false);
+
+  const handleConnect = async () => {
+    try {
+      setConnecting(true);
+      const result = await apiClient.getSlackAuthUrl(tenantId);
+      
+      if (result.success) {
+        // Open OAuth URL in new window
+        window.open(result.authorization_url, '_blank', 'width=600,height=700');
+        
+        // Start polling for authentication completion
+        startPolling();
+        
+        // Stop polling after 5 minutes
+        setTimeout(() => {
+          stopPolling();
+          setConnecting(false);
+        }, 300000);
+      }
+    } catch (err) {
+      console.error('Failed to start OAuth flow:', err);
+      setConnecting(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    const success = await refreshToken();
+    if (success) {
+      console.log('Token refreshed successfully');
+    }
+  };
+
+  // Show loading only on initial load, not during polling
+  if (loading && !polling) {
+    return (
+      <div className="card mt-4">
+        <div className="card-body">
+          <div className="d-flex align-items-center">
+            <div className="spinner-border spinner-border-sm me-2" role="status">
+              <span className="visually-hidden">Loading...</span>
+            </div>
+            <span>Checking Slack connection...</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="card mt-4">
+        <div className="card-body">
+          <div className="alert alert-danger">
+            <strong>Error:</strong> {error}
+          </div>
+          <button className="btn btn-primary" onClick={checkAuth}>
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (authStatus?.authenticated) {
+    return (
+      <div className="card mt-4">
+        <div className="card-header bg-success-subtle">
+          <div className="d-flex justify-content-between align-items-center w-100">
+            <h3 className="mb-0">Slack Integration</h3>
+            <div className="d-flex align-items-center ms-auto">
+              {polling && (
+                <div className="spinner-border spinner-border-sm text-success me-2" role="status">
+                  <span className="visually-hidden">Refreshing...</span>
+                </div>
+              )}
+              <span className="text-success fw-bold">Connected ✔</span>
+            </div>
+          </div>
+        </div>
+        <div className="card-body">
+          <div className="row">
+            <div className="col-md-8">
+              {authStatus.team && (
+                <div className="mb-2">
+                  <strong>Workspace:</strong> {authStatus.team}
+                </div>
+              )}
+              {authStatus.scopes && authStatus.scopes.length > 0 && (
+                <div className="mb-2">
+                  <strong>Scopes:</strong> {authStatus.scopes.join(', ')}
+                </div>
+              )}
+              <div className="text-muted small">
+                {authStatus.message}
+              </div>
+            </div>
+            <div className="col-md-4 text-end">
+              <button 
+                className="btn btn-outline-primary btn-sm" 
+                onClick={handleRefresh} 
+                disabled={connecting || loading}
+              >
+                Refresh Token
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (authStatus?.can_refresh) {
+    return (
+      <div className="card mt-4">
+        <div className="card-header bg-warning-subtle">
+          <div className="d-flex justify-content-between align-items-center">
+            <h3>Slack Integration</h3>
+            <span className="text-warning fw-bold">⚠️ Token Expired</span>
+          </div>
+        </div>
+        <div className="card-body">
+          <div className="row">
+            <div className="col-md-8">
+              <p className="text-muted mb-0">
+                Your Slack token has expired, but it can be refreshed automatically.
+              </p>
+            </div>
+            <div className="col-md-4 text-end">
+              <button 
+                className="btn btn-warning" 
+                onClick={handleRefresh} 
+                disabled={connecting || loading}
+              >
+                {loading ? 'Refreshing...' : 'Refresh Connection'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card mt-4">
+      <div className="card-header">
+        <div className="d-flex justify-content-between align-items-center">
+          <h3>Slack Integration</h3>
+          <div className="d-flex align-items-center">
+            <span className="text-muted me-2">🔗</span>
+            {polling && (
+              <div className="spinner-border spinner-border-sm text-muted" role="status">
+                <span className="visually-hidden">Checking...</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="card-body">
+        <div className="row">
+          <div className="col-md-8">
+            <p className="text-muted mb-0">
+              Connect your Slack workspace to sync messages and channels.
+            </p>
+            {polling && (
+              <div className="text-muted small mt-2">
+                <i className="fas fa-sync-alt me-1"></i>
+                Waiting for authentication...
+              </div>
+            )}
+          </div>
+          <div className="col-md-4 text-end">
+            <button 
+              className="btn btn-primary" 
+              onClick={handleConnect} 
+              disabled={connecting || polling}
+            >
+              {connecting ? 'Connecting...' : 'Connect to Slack'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SlackConnectCard;

--- a/client/src/hooks/useSlackAuth.ts
+++ b/client/src/hooks/useSlackAuth.ts
@@ -1,0 +1,108 @@
+import { useState, useEffect, useRef } from 'react';
+import { apiClient, SlackAuthStatus } from '../lib/api';
+
+interface UseSlackAuthProps {
+  tenantId: string;
+}
+
+interface UseSlackAuthReturn {
+  authStatus: SlackAuthStatus | null;
+  loading: boolean;
+  polling: boolean;
+  error: string | null;
+  checkAuth: () => Promise<void>;
+  refreshToken: () => Promise<boolean>;
+  startPolling: () => void;
+  stopPolling: () => void;
+}
+
+export const useSlackAuth = ({ tenantId }: UseSlackAuthProps): UseSlackAuthReturn => {
+  const [authStatus, setAuthStatus] = useState<SlackAuthStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [polling, setPolling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollingRef = useRef<NodeJS.Timeout | null>(null);
+
+  const checkAuth = async (isPolling: boolean = false) => {
+    try {
+      if (!isPolling) {
+        setLoading(true);
+      }
+      setError(null);
+      const status = await apiClient.getSlackAuthStatus(tenantId);
+      setAuthStatus(status);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to check authentication status');
+    } finally {
+      if (!isPolling) {
+        setLoading(false);
+      }
+    }
+  };
+
+  const refreshToken = async (): Promise<boolean> => {
+    if (!authStatus?.integration_id) return false;
+    
+    try {
+      setLoading(true);
+      setError(null);
+      const result = await apiClient.refreshSlackToken(tenantId, authStatus.integration_id);
+      
+      if (result.success) {
+        // Re-check auth status after refresh
+        await checkAuth();
+        return true;
+      }
+      return false;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to refresh token');
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const startPolling = () => {
+    if (pollingRef.current) return; // Already polling
+    
+    setPolling(true);
+    pollingRef.current = setInterval(async () => {
+      await checkAuth(true); // Pass true to indicate this is a polling call
+      if (authStatus?.authenticated) {
+        stopPolling();
+      }
+    }, 3000); // Poll every 3 seconds
+  };
+
+  const stopPolling = () => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+    setPolling(false);
+  };
+
+  useEffect(() => {
+    checkAuth();
+  }, [tenantId]);
+
+  // Cleanup polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    authStatus,
+    loading,
+    polling,
+    error,
+    checkAuth,
+    refreshToken,
+    startPolling,
+    stopPolling
+  };
+};

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -24,6 +24,30 @@ export interface HubSpotAuthStatus {
   can_refresh?: boolean;
 }
 
+export interface SlackAuthStatus {
+  authenticated: boolean;
+  message: string;
+  needs_auth: boolean;
+  integration_id?: string;
+  team?: string;
+  scopes?: string[];
+  can_refresh?: boolean;
+}
+
+export interface SlackAuthUrlResponse {
+  success: boolean;
+  authorization_url: string;
+  integration_id: string;
+  tenant_id: string;
+}
+
+export interface SlackRefreshResponse {
+  success: boolean;
+  message: string;
+  integration_id: string;
+  tenant_id: string;
+}
+
 export interface JiraStatus {
   connected: boolean;
   user?: {
@@ -277,6 +301,22 @@ export const apiClient = {
 
   async refreshHubSpotToken(tenantId: string, integrationId: string): Promise<{ success: boolean; message: string }> {
     const response = await api.post<{ success: boolean; message: string }>(`/api/hubspot/refresh-token/${tenantId}/${integrationId}`);
+    return response.data;
+  },
+
+  // Slack API
+  async getSlackAuthUrl(tenantId: string): Promise<SlackAuthUrlResponse> {
+    const response = await api.get<SlackAuthUrlResponse>(`/api/slack/authorize/${tenantId}`);
+    return response.data;
+  },
+
+  async getSlackAuthStatus(tenantId: string): Promise<SlackAuthStatus> {
+    const response = await api.get<SlackAuthStatus>(`/api/slack/auth-status/${tenantId}`);
+    return response.data;
+  },
+
+  async refreshSlackToken(tenantId: string, integrationId: string): Promise<SlackRefreshResponse> {
+    const response = await api.post<SlackRefreshResponse>(`/api/slack/refresh-token/${tenantId}/${integrationId}`);
     return response.data;
   },
 

--- a/client/src/pages/Integrations.tsx
+++ b/client/src/pages/Integrations.tsx
@@ -4,11 +4,9 @@ import { apiClient } from '../lib/api';
 import HubSpotConnectCard from '../components/HubSpotConnectCard';
 import { JiraApiTokenForm } from '../components/JiraApiTokenForm';
 import { JiraIntegrationStatus } from '../components/JiraIntegrationStatus';
-import ConnectSlackCard from '../components/ConnectSlackCard';
-import SlackChannelPicker from '../components/SlackChannelPicker';
-import SlackIntegrationStatus from '../components/SlackIntegrationStatus';
+import SlackConnectCard from '../components/SlackConnectCard';
 
-import IntegrationStatus from '../components/IntegrationStatus';
+
 import { useHubSpot } from '../hooks/useHubSpot';
 import { useTenant } from '../context/TenantContext';
 import { TransformedHubSpotTicket } from '../lib/api';
@@ -23,8 +21,6 @@ const Integrations: React.FC = () => {
   const [message, setMessage] = useState<string | null>(null);
   const [showSuccess, setShowSuccess] = useState(false);
   const [jiraIntegrationId, setJiraIntegrationId] = useState<string | null>(null);
-  const [slackIntegrationId, setSlackIntegrationId] = useState<string | null>(null);
-  const [showSlackChannelPicker, setShowSlackChannelPicker] = useState(false);
   const [jiraIssues, setJiraIssues] = useState<any[]>([]);
   const [jiraLoading, setJiraLoading] = useState(false);
   const integrationId = localStorage.getItem('hubspot_integration_id') || '550e8400-e29b-41d4-a716-446655440001';
@@ -381,60 +377,12 @@ const Integrations: React.FC = () => {
                 <h3>Slack Integration</h3>
                 <p>Connect your Slack workspace to sync messages and analyze them for customer issues.</p>
                 
-                {!slackIntegrationId && !showSlackChannelPicker && (
-                  <ConnectSlackCard
-                    tenantId={tenantId}
-                    onSuccess={(integrationId: string) => {
-                      console.log('Slack integration created:', integrationId);
-                      setSlackIntegrationId(integrationId);
-                      setShowSlackChannelPicker(true);
-                      setMessage('Slack connected successfully! Now select channels to sync.');
-                      setTimeout(() => setMessage(null), 5000);
-                    }}
-                    onError={(error: string) => {
-                      console.error('Slack connection failed:', error);
-                      setMessage(`Slack connection failed: ${error}`);
-                    }}
-                  />
-                )}
-
-                {(slackIntegrationId || showSlackChannelPicker) && (
-                  <>
-                    <div className="mb-4">
-                      <SlackIntegrationStatus
-                        tenantId={tenantId}
-                        onRefresh={() => {
-                          // Refresh logic if needed
-                        }}
-                      />
-                    </div>
-
-                    <div className="mb-4">
-                      <SlackChannelPicker
-                        tenantId={tenantId}
-                        onChannelsUpdated={(selectedChannels: string[]) => {
-                          console.log('Channels updated:', selectedChannels);
-                          setMessage(`Selected ${selectedChannels.length} channels for sync.`);
-                          setTimeout(() => setMessage(null), 3000);
-                        }}
-                        onSyncComplete={(ingestedCount: number) => {
-                          console.log('Sync completed:', ingestedCount);
-                          setMessage(`Sync completed! Ingested ${ingestedCount} messages. Check the AI Issues dashboard for results.`);
-                          setTimeout(() => setMessage(null), 8000);
-                        }}
-                        onError={(error: string) => {
-                          console.error('Slack error:', error);
-                          setMessage(`Slack error: ${error}`);
-                        }}
-                      />
-                    </div>
-                  </>
-                )}
+                <SlackConnectCard />
 
                 <div className="mt-4 p-3 bg-light rounded">
                   <h6 className="mb-2">💡 How it works</h6>
                   <ol className="mb-0 small">
-                    <li>Connect your Slack workspace with a bot token</li>
+                    <li>Connect your Slack workspace using OAuth (no manual token needed)</li>
                     <li>Select channels containing customer feedback or bug reports</li>
                     <li>Sync messages to analyze for issues and patterns</li>
                     <li>View AI-grouped issues on the Dashboard with Slack source data</li>


### PR DESCRIPTION
- Add SlackAuthStatus, SlackAuthUrlResponse, and SlackRefreshResponse interfaces
- Create useSlackAuth hook for managing OAuth authentication state
- Add SlackConnectCard component with OAuth popup flow
- Update Integrations page to use new OAuth-based Slack connection
- Replace manual token entry with seamless OAuth authentication
- Add polling mechanism for OAuth completion detection
- Support token refresh functionality for expired tokens
- Match UI design with existing HubSpot integration